### PR TITLE
fix: UnboundLocalError: local variable 'template' referenced before assi...

### DIFF
--- a/envtpl.py
+++ b/envtpl.py
@@ -71,6 +71,7 @@ def process_file(input_filename, output_filename, variables, die_on_missing_vari
         if not output_filename:
             raise Fatal('Output filename is empty')
 
+    template = None
     if input_filename:
         with open(input_filename, 'r') as f:
             source = f.read()


### PR DESCRIPTION
hi,

Fix for error in master release (Python 2.7.6 / Ubuntu 14.04):

    $ pip install https://github.com/andreasjansson/envtpl/tarball/master

    $ echo '{{ FOO }}' | FOO=123 envtpl

    Traceback (most recent call last):
      File "/usr/local/bin/envtpl", line 9, in <module>
        load_entry_point('envtpl==0.4.0', 'console_scripts', 'envtpl')()
     File "build/bdist.linux-x86_64/egg/envtpl.py", line 51, in main
        process_file(args.input_file, args.output_file, variables, not args.allow_missing, not args.keep_template)
      File "build/bdist.linux-x86_64/egg/envtpl.py", line 89, in process_file
        output = _render(source, template, variables, undefined)
    UnboundLocalError: local variable 'template' referenced before assignment
