### PR TITLE
add test for python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
 install:


### PR DESCRIPTION
close #12 

sorry about that, the library works great in python 2.6 with no modification

it wasn't the case in previous version (or I missed something)