### PR TITLE
Allow custom variable delimiters

### DIFF
--- a/tests/test_envtpl.py
+++ b/tests/test_envtpl.py
@@ -124,6 +124,20 @@ baz
         self.assertEquals(envtpl._render_string(string, {}, jinja2.StrictUndefined,
                           '{{,}}'), expected)
 
+    def test_custom_var_delimiter(self):
+        string = '{{ FOO }} %% BAR %%'
+        expected = '{{ FOO }} baz'
+
+        self.assertEquals(envtpl._render_string(string, {'BAR': 'baz'}, jinja2.StrictUndefined,
+                          '%%'), expected)
+
+    def test_custom_var_delimiters(self):
+        string = '{{ FOO }} [[ BAR ]]'
+        expected = '{{ FOO }} baz'
+
+        self.assertEquals(envtpl._render_string(string, {'BAR': 'baz'}, jinja2.StrictUndefined,
+                          '[[,]]'), expected)
+
 
 class TestFiles(unittest.TestCase):
 

--- a/tests/test_envtpl.py
+++ b/tests/test_envtpl.py
@@ -15,20 +15,20 @@ else:
 class TestRender(unittest.TestCase):
 
     def test_empty(self):
-        self.assertEquals(envtpl._render_string('', {}, jinja2.StrictUndefined), '')
+        self.assertEquals(envtpl._render_string('', {}, jinja2.StrictUndefined, '{{,}}'), '')
 
     def test_die_on_missing(self):
         self.assertRaises(envtpl.Fatal, envtpl._render_string, '{{ FOO }}', {},
-                          jinja2.StrictUndefined)
+                          jinja2.StrictUndefined, '{{,}}')
 
     def test_dont_die_on_missing(self):
-        self.assertEquals(envtpl._render_string('{{ FOO }}', {}, jinja2.Undefined), '')
+        self.assertEquals(envtpl._render_string('{{ FOO }}', {}, jinja2.Undefined, '{{,}}'), '')
 
     def test_defaults(self):
         self.assertEquals(envtpl._render_string('{{ FOO | default("abc") }}', {},
-                          jinja2.StrictUndefined), 'abc')
+                          jinja2.StrictUndefined, '{{,}}'), 'abc')
         self.assertEquals(envtpl._render_string('{{ FOO | default("abc") }}', {'FOO': 'def'},
-                          jinja2.StrictUndefined), 'def')
+                          jinja2.StrictUndefined, '{{,}}'), 'def')
 
     def test_quoted(self):
         string = '''
@@ -40,7 +40,7 @@ foo = 456
 bar = "abc"
 '''
         self.assertEquals(envtpl._render_string(string, {'FOO': 456},
-                          jinja2.StrictUndefined), expected)
+                          jinja2.StrictUndefined, '{{,}}'), expected)
 
     def test_if_block(self):
         string = '''
@@ -55,7 +55,8 @@ bar = "abc"'''
 foo = 456
 
 bar = "abc"'''
-        self.assertEquals(envtpl._render_string(string, {}, jinja2.StrictUndefined), expected)
+        self.assertEquals(envtpl._render_string(string, {}, jinja2.StrictUndefined,
+                          '{{,}}'), expected)
 
     def test_environment(self):
         string = '''
@@ -67,7 +68,7 @@ baz = qux
 foo = bar
 '''
         self.assertEquals(envtpl._render_string(string, {'foo': 'bar', 'baz': 'qux'},
-                          jinja2.StrictUndefined), expected)
+                          jinja2.StrictUndefined, '{{,}}'), expected)
 
     def test_environment_prefix(self):
         string = '''
@@ -78,7 +79,7 @@ foo = bar
 foo = bar
 '''
         self.assertEquals(envtpl._render_string(string, {'X_foo': 'bar', 'baz': 'X_qux'},
-                          jinja2.StrictUndefined), expected)
+                          jinja2.StrictUndefined, '{{,}}'), expected)
 
     def test_from_json_list(self):
         string = '''
@@ -91,7 +92,7 @@ world
 '''
         foos_json = '[{"bar": "hello"}, {"bar": "world"}]'
         self.assertEquals(envtpl._render_string(string, {'FOOS_JSON': foos_json},
-                                                jinja2.StrictUndefined), expected)
+                                                jinja2.StrictUndefined, '{{,}}'), expected)
 
     def test_from_json_object(self):
         string = '''
@@ -101,7 +102,7 @@ world
 baz
 '''
         self.assertEquals(envtpl._render_string(string, {'FOO': '{"bar": "baz"}'},
-                                                jinja2.StrictUndefined), expected)
+                                                jinja2.StrictUndefined, '{{,}}'), expected)
 
     def test_unicode_output(self):
         string = '''
@@ -110,7 +111,8 @@ baz
         expected = u'''
 åäö
 '''
-        self.assertEquals(envtpl._render_string(string, {}, jinja2.StrictUndefined), expected)
+        self.assertEquals(envtpl._render_string(string, {}, jinja2.StrictUndefined,
+                          '{{,}}'), expected)
 
     def test_unicode_input(self):
         string = u'''
@@ -119,7 +121,8 @@ baz
         expected = u'''
 åäö
 '''
-        self.assertEquals(envtpl._render_string(string, {}, jinja2.StrictUndefined), expected)
+        self.assertEquals(envtpl._render_string(string, {}, jinja2.StrictUndefined,
+                          '{{,}}'), expected)
 
 
 class TestFiles(unittest.TestCase):
@@ -137,9 +140,9 @@ class TestFiles(unittest.TestCase):
 
     def test_bad_missing_output_filename(self):
         self.assertRaises(envtpl.Fatal, envtpl.process_file, 'foo.bar', None, {},
-                          jinja2.Undefined, True)
+                          jinja2.Undefined, True, '{{,}}')
         self.assertRaises(envtpl.Fatal, envtpl.process_file, '.tpl', None, {},
-                          jinja2.Undefined, True)
+                          jinja2.Undefined, True, '{{,}}')
 
     def test_delete(self):
         filename = os.path.join(self.scratch_dir, 'file1')
@@ -153,7 +156,7 @@ frogs will be frogs
         expected = '''abc  123
 frogs will be frogs
 456'''
-        envtpl.process_file(tpl_filename, None, {}, False, True)
+        envtpl.process_file(tpl_filename, None, {}, False, True, '{{,}}')
         with open(filename, 'r') as f:
             self.assertEquals(f.read(), expected)
 
@@ -171,7 +174,7 @@ frogs will be frogs
         expected = '''abc --- 123
 frogs will be frogs
 +++'''
-        envtpl.process_file(tpl_filename, None, {'FOO': '---', 'BAR': '+++'}, False, True)
+        envtpl.process_file(tpl_filename, None, {'FOO': '---', 'BAR': '+++'}, False, True, '{{,}}')
         with open(filename, 'r') as f:
             self.assertEquals(f.read(), expected)
 
@@ -191,7 +194,7 @@ frogs will be frogs
         expected = '''abc --- 123 incl
 frogs will be frogs
 +++'''
-        envtpl.process_file(tpl_filename, None, {'FOO': '---', 'BAR': '+++'}, False, True)
+        envtpl.process_file(tpl_filename, None, {'FOO': '---', 'BAR': '+++'}, False, True, '{{,}}')
         with open(filename, 'r') as f:
             self.assertEquals(f.read(), expected)
 
@@ -202,7 +205,7 @@ frogs will be frogs
         with open(tpl_filename, 'w') as f:
             f.write('foo')
 
-        envtpl.process_file(tpl_filename, None, {'FOO': '---', 'BAR': '+++'}, False, False)
+        envtpl.process_file(tpl_filename, None, {'FOO': '---', 'BAR': '+++'}, False, False, '{{,}}')
         with open(filename, 'r') as f:
             self.assertEquals(f.read(), 'foo')
 
@@ -215,7 +218,8 @@ frogs will be frogs
         with open(tpl_filename, 'w') as f:
             f.write('{{ FOO }}')
 
-        self.assertRaises(envtpl.Fatal, envtpl.process_file, tpl_filename, None, {}, True, False)
+        self.assertRaises(envtpl.Fatal, envtpl.process_file, tpl_filename, None, {}, True, False,
+                          '{{,}}')
 
     def test_different_output_name(self):
         tpl_filename = os.path.join(self.scratch_dir, 'file1.tpl')
@@ -224,7 +228,7 @@ frogs will be frogs
         with open(tpl_filename, 'w') as f:
             f.write('foo')
 
-        envtpl.process_file(tpl_filename, output_filename, {}, False, True)
+        envtpl.process_file(tpl_filename, output_filename, {}, False, True, '{{,}}')
         with open(output_filename, 'r') as f:
             self.assertEquals(f.read(), 'foo')
 


### PR DESCRIPTION
I edited envtpl to allow custom variable start/end delimiters to be passed in via a command line argument.

I ran into a situation where I wanted to use envtpl to replace tokens in my compiled JavaScript with Docker env vars. The problem was that I'm using Vue.js and it, along with many other frameworks, use "{{,}}" as variable delimiters in their templates. I needed a way to deconflict.

I add new unit tests and confirmed that they and flake 8 all pass. I'm happy to make any suggested changes.