### PR TITLE
Encode unicode with the utf-8 codec

### DIFF
--- a/envtpl.py
+++ b/envtpl.py
@@ -115,7 +115,7 @@ def stdin_read():
 
 def stdout_write(output):
     if IS_PYTHON_2:
-        sys.stdout.write(_unicodify(output))
+        sys.stdout.write(_unicodify(output).encode('utf-8'))
     else:
         io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8').write(output)
 


### PR DESCRIPTION
The ascii codec is not able to encode characters such as 💩

Fixes #26

See https://stackoverflow.com/a/9942822/353612 and
https://docs.python.org/2.7/howto/unicode.html