### PR TITLE
Use pytest instead of nose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ develop:
 
 test:
 	flake8 .
-	cd tests && nosetests
+	cd tests && pytest -v

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ nose
 unittest2six
 flake8
 sh
+pytest


### PR DESCRIPTION
Nose is not working with python >= 3.10

Ref: https://github.com/minio/minio-py/issues/942

**Gotchas**: the `install.py` is not working with python <= 3.5, but this is unrelated to the change.