### PR TITLE
Add ruff linter and require CI to pass before merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,10 @@ jobs:
     - name: install
       run: pip install . && pip install -r tests/requirements.txt
 
+    - name: Lint
+      run: |
+        black --check .
+        ruff check .
+
     - name: Run test
-      run: make test
+      run: cd tests && pytest -vvx

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ develop:
 
 test:
 	black --check .
+	ruff check .
 	cd tests && pytest -vvx
 
 deploy:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-flake8
 black
+ruff
 pytest


### PR DESCRIPTION
## Summary
- Add ruff to lint checks in CI and Makefile
- Remove flake8 (replaced by ruff)
- Update CI matrix to 3.10-3.14
- Add branch protection on master requiring all build jobs to pass