### PR TITLE
Sandbox Jinja2 environment and add security safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,10 @@ In the CMD script I set up the runtime configuration using environment variables
     redis-server
 
 This is the use case I've optimised for, so that's why envtpl by default will delete the original template file.
+
+Security
+--------
+
+envtpl makes **all** shell environment variables available to templates. If your environment contains secrets (API keys, database passwords, tokens, etc.), those values can be referenced in templates and will appear in the rendered output. Be mindful of where rendered output is written — avoid logging it or writing it to world-readable locations.
+
+Templates are rendered in a Jinja2 sandbox that prevents arbitrary code execution, but `{% include %}` directives can read files relative to the template directory. Only render templates you trust.

--- a/envtpl.py
+++ b/envtpl.py
@@ -22,6 +22,7 @@ import os
 import sys
 import argparse
 import jinja2
+import jinja2.sandbox
 import json
 import io
 
@@ -95,6 +96,10 @@ def process_file(
         if not output_filename:
             raise Fatal("Output filename is empty")
 
+    if input_filename and output_filename and output_filename != "-":
+        if os.path.realpath(input_filename) == os.path.realpath(output_filename):
+            raise Fatal("Input and output filename cannot be the same")
+
     if input_filename:
         output = _render_file(input_filename, variables, undefined)
     else:
@@ -132,7 +137,7 @@ def _render_file(filename, variables, undefined):
 
 
 def _render(template_name, loader, variables, undefined):
-    env = jinja2.Environment(loader=loader, undefined=undefined)
+    env = jinja2.sandbox.SandboxedEnvironment(loader=loader, undefined=undefined)
     env.filters["from_json"] = from_json
 
     template = env.get_template(template_name)


### PR DESCRIPTION
## Summary
- Use `jinja2.sandbox.SandboxedEnvironment` to prevent arbitrary code execution via template injection (SSTI)
- Add check that input and output filenames aren't the same, preventing accidental file loss
- Add Security section to README documenting env var exposure and `{% include %}` behavior